### PR TITLE
fix: update Dockerfile entrypoint to use Anexia webhook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM gcr.io/distroless/static-debian12:nonroot
 USER 20000:20000
 COPY --chmod=555 external-dns-anexia-webhook /opt/external-dns-anexia-webhook/app
 
-ENTRYPOINT ["/opt/external-dns-ionos-webhook/app"]
+ENTRYPOINT ["/opt/external-dns-anexia-webhook/app"]


### PR DESCRIPTION
Previously the entrypoint into the docker images was not correctly set up. It was still the path carried over from the ionos implementation.