### PR TITLE
fix: reorder record parsing in GetRecords function

### DIFF
--- a/internal/anexia/provider.go
+++ b/internal/anexia/provider.go
@@ -73,10 +73,9 @@ func (c *DNSClient) GetRecords(ctx context.Context) ([]*anxcloudDns.Record, erro
 		}
 	}
 
-	record := anxcloudDns.Record{}
-
 	records := make([]*anxcloudDns.Record, 0)
 	for res := range channel {
+		record := anxcloudDns.Record{}
 		if err := res(&record); err != nil {
 			log.Errorf("failed to parse record: %v", err)
 			return nil, err


### PR DESCRIPTION
The code changes in `provider.go` fix the issue with record parsing in the `GetRecords` function. Previously, the `record` variable was declared outside the loop, causing overwriting already parsed records. This commit moves the declaration of `record` inside the loop to ensure correct parsing.