### PR TITLE
Fixed typo in example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sidecars:
       - name: ANEXIA_API_TOKEN
         valueFrom:
           secretKeyRef:
-            name: aneixa-configuration
+            name: anexia-configuration
             key: token
       - name: SERVER_HOST
         value: "0.0.0.0"


### PR DESCRIPTION
The current configuration contains a typo which will lead to an error message like

```
Error: secret "aneixa-configuration" not found
```

This PR fixes the typo.