### PR TITLE
fix: update goreleaser config to work with v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,7 +98,7 @@ docker_manifests:
       - ghcr.io/probstenhias/external-dns-anexia-webhook:{{ .Env.CI_COMMIT_TAG }}-arm64
       - ghcr.io/probstenhias/external-dns-anexia-webhook:{{ .Env.CI_COMMIT_TAG }}-armv7
 changelog:
-  skip: true
+  disable: true
   use: github
   filters:
     exclude:


### PR DESCRIPTION
Update the config for goreleaser to support v2. This is required as with github actions version 6 of goreleaser v2 is required